### PR TITLE
fix: quoted file path

### DIFF
--- a/base_test.go
+++ b/base_test.go
@@ -253,7 +253,7 @@ var genericTests = map[string]struct {
 		"",
 	},
 	"testdata/test_directive_unknown.conf": {
-		4,
+		1,
 		"test should fail with unknown directive",
 	},
 	"testdata/test_34_xml.conf": {

--- a/parser/SecLangLexer.g4
+++ b/parser/SecLangLexer.g4
@@ -19,7 +19,7 @@ limitations under the License.
 lexer grammar SecLangLexer;
 
 tokens {
-	QUOTE, SINGLE_QUOTE, EQUAL, COLON, EQUALS_PLUS, EQUALS_MINUS, COMMA, PIPE
+	QUOTE, SINGLE_QUOTE, EQUAL, COLON, EQUALS_PLUS, EQUALS_MINUS, COMMA, PIPE, CONFIG_VALUE_PATH
 }
 
 WS
@@ -1198,8 +1198,22 @@ WS_FILE_PATH_MODE
 	: WS -> skip
 	;
 
-CONFIG_VALUE_PATH
-	: ('/' | LETTER | DIGIT | '.' | '_' | '~' | '|' | '\\' | ':' | '-')+ -> popMode
+FILE_PATH_QUOTE
+	: '"' -> type(QUOTE), pushMode(QUOTED_FILE_PATH)
+	;
+
+CONFIG_VALUE_PATH_DEFAULT
+	: ('/' | LETTER | DIGIT | '.' | '_' | '~' | '|' | '\\' | ':' | '-')+ -> type(CONFIG_VALUE_PATH), popMode
+	;
+
+mode QUOTED_FILE_PATH;
+
+CONFIG_VALUE_PATH_DEFAULT_QUOTED
+	: CONFIG_VALUE_PATH_DEFAULT -> type(CONFIG_VALUE_PATH)
+	;
+
+FILE_PATH_CLOSE_QUOTE
+	: '"' -> type(QUOTE), pushMode(DEFAULT_MODE)
 	;
 
 mode XPATH;

--- a/parser/SecLangParser.g4
+++ b/parser/SecLangParser.g4
@@ -44,7 +44,8 @@ rules_directive:
     ;
 
 engine_config_directive:
-    stmt_audit_log
+    stmt_audit_log values
+    | stmt_audit_log QUOTE values QUOTE
     | engine_config_action_directive actions
     | string_engine_config_directive QUOTE values QUOTE
     | sec_marker_directive QUOTE values QUOTE
@@ -196,6 +197,7 @@ values:
     | CONFIG_VALUE_DETC
     | CONFIG_VALUE_PROCESS_PARTIAL
     | CONFIG_VALUE_REJECT
+    | CONFIG_VALUE_PATH INT
     | CONFIG_VALUE_PATH
     | STRING
     | VARIABLE_NAME

--- a/testdata/test_04_directives.conf
+++ b/testdata/test_04_directives.conf
@@ -4,3 +4,7 @@ SecTmpDir /tmp/
 SecDataDir /tmp/
 
 SecUnicodeMapFile unicode.mapping 20127
+
+SecAuditLog /path/to/audit.log
+
+SecAuditLog "/path/to/audit.log"

--- a/testdata/test_directive_unknown.conf
+++ b/testdata/test_directive_unknown.conf
@@ -1,4 +1,4 @@
 
 # Test unknown directives
 
-SecUnknown "id:1,nolog"
+SecUnknown


### PR DESCRIPTION
Allow quoted file paths in directives with file path values (e.g., SecAuditLog)