### PR TITLE
fix: negated operators

### DIFF
--- a/listener.go
+++ b/listener.go
@@ -16,6 +16,7 @@ type ParserResult struct {
 	collectionArgs        []string
 	operatorList          []string
 	operatorValueList     []string
+	negatedOperatorCount  int
 	directiveList         []string
 	directiveValues       []string
 	rangeEvents           []string
@@ -146,4 +147,8 @@ func (l *TreeShapeListener) EnterOperator_name(ctx *parser.Operator_nameContext)
 
 func (l *TreeShapeListener) EnterOperator_value(ctx *parser.Operator_valueContext) {
 	l.results.operatorValueList = append(l.results.operatorValueList, ctx.GetText())
+}
+
+func (l *TreeShapeListener) EnterOperator_not(ctx *parser.Operator_notContext) {
+	l.results.negatedOperatorCount++
 }

--- a/parser/SecLangLexer.g4
+++ b/parser/SecLangLexer.g4
@@ -19,7 +19,7 @@ limitations under the License.
 lexer grammar SecLangLexer;
 
 tokens {
-	QUOTE, SINGLE_QUOTE, EQUAL, COLON, EQUALS_PLUS, EQUALS_MINUS, COMMA, PIPE, CONFIG_VALUE_PATH
+	QUOTE, SINGLE_QUOTE, EQUAL, COLON, EQUALS_PLUS, EQUALS_MINUS, COMMA, PIPE, CONFIG_VALUE_PATH, NOT
 }
 
 WS
@@ -86,8 +86,8 @@ NOT_EQUAL
    : '<>'
    ;
 
-NOT
-    : '!'
+NOT_DEFAULT
+    : '!' -> type(NOT)
     ;
 
 LT
@@ -1318,6 +1318,10 @@ PIPE_COL_ELEM
 
 mode OPERATOR_START_MODE;
 
+NOT_OPERATOR
+	: '!' -> type(NOT)
+	;
+
 SKIP_CHARS
    : [\\\t\r\n ]+  -> skip 
    ;
@@ -1332,11 +1336,15 @@ OPERATOR_UNQUOTED_STRING
 
 mode OPERATOR_WITH_QUOTES;
 
+NOT_OPERATOR_WITH_QUOTES
+   : '!' -> type(NOT)
+   ;
+
 AT
    : '@' -> pushMode(DEFAULT_MODE)
    ;
 
 OPERATOR_QUOTED_STRING
-    : (('\\"') | ~([" @])) (('\\"')|~('"'))* -> pushMode(DEFAULT_MODE)
+    : (('\\"') | ~([" @!])) (('\\"')|~('"'))* -> pushMode(DEFAULT_MODE)
     ;
 

--- a/parser/SecLangParser.g4
+++ b/parser/SecLangParser.g4
@@ -242,8 +242,12 @@ update_target_rules_values:
     | STRING
     ;
 
+operator_not:
+    NOT
+    ;
+
 operator:
-    QUOTE NOT? AT operator_name operator_value? QUOTE
+    QUOTE operator_not? AT operator_name operator_value? QUOTE
     | QUOTE operator_value QUOTE
     | operator_value
     ;

--- a/parser_test.go
+++ b/parser_test.go
@@ -294,6 +294,16 @@ var checkOutputTests = map[string]struct {
 			rangeStartEvents:      []int{42, 65, 97},
 			rangeEndEvents:        []int{59, 90, 122},
 		},
+	}, "testdata/test_41_negated_operator.conf": {
+		0,
+		"",
+		ParserResult{
+			collections:          []string{"ARGS", "ARGS_NAMES"},
+			operatorList:         []string{"rx"},
+			operatorValueList:    []string{"foo"},
+			negatedOperatorCount: 1,
+			directiveList:        []string{"SecRule"},
+		},
 	},
 }
 

--- a/testdata/test_41_negated_operator.conf
+++ b/testdata/test_41_negated_operator.conf
@@ -1,0 +1,6 @@
+
+SecRule ARGS|ARGS_NAMES "!@rx foo" \
+    "id:1,\
+    phase:2,\
+    nolog,
+    pass"


### PR DESCRIPTION
## what
- fixed parser behavior when parsing negated operators such as ```"!@rx foo"```.
- added parser event for operator negation token.
## why
- the `!` token wasn't recognized and the parser interpreted all contents inside quotes as the operator value of the default `rx` operator.